### PR TITLE
CI check

### DIFF
--- a/interface/vsomeip/plugin.hpp
+++ b/interface/vsomeip/plugin.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <stdint.h>
 
 #if _WIN32
     #if VSOMEIP_DLL_COMPILATION_PLUGIN

--- a/interface/vsomeip/plugins/application_plugin.hpp
+++ b/interface/vsomeip/plugins/application_plugin.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <memory>
+#include <stdint.h>
 
 #include <vsomeip/export.hpp>
 


### PR DESCRIPTION
GCC 15 requires stdint.h to be explicitly imported: https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes